### PR TITLE
Add unoptimized flag to the Image tags

### DIFF
--- a/components/media-items/media-items-list.tsx
+++ b/components/media-items/media-items-list.tsx
@@ -61,6 +61,7 @@ const MediaItemList: FunctionComponent<MediaItemListProps> = ({
               mediaItems[index].mediaMetadata.creationTime
             ).toLocaleString()}
             layout="fill"
+            unoptimized
           />
         </article>
       ))}


### PR DESCRIPTION
This is necessary to avoid exceeding Vercel's monthly usage limits